### PR TITLE
Sync to latest cities/desks, use consistent naming

### DIFF
--- a/.env
+++ b/.env
@@ -8,18 +8,24 @@ IND_CURRENT_APPOINTMENT_BIOMETRICS=
 IND_CURRENT_APPOINTMENT_RESIDENCE_STICKER=
 IND_CURRENT_APPOINTMENT_RESIDENCE_CARD=
 
-# Comma-seperated list of cities you want to target.
+# Comma-seperated list of cities/desks you want to target.
 #
-# All cities will be selected if the value is empty.
+# All cities/desks will be selected if the value is empty.
 # Otherwise, enumerate them from the options below:
-# - Amsterdam
-# - The Hague
-# - Rotterdam
-# - Zwolle
-# - Den Bosch
+# - IND Amsterdam
+# - IND Den Haag
+# - IND Zwolle
+# - IND Den Bosch
+# - IND Rotterdam
 # - IND Haarlem
-# - Expat center Utrecht
-# - Expat center Rotterdam
-# - Expat center Enschede
+# - Expatcenter Groningen
+# - Expatcenter Maastricht
+# - Expatcenter Wageningen
+# - Expatcenter Eindhoven
+# - Expatcenter DenHaag
+# - Expatcenter Rotterdam
+# - Expatcenter Enschede
+# - Expatcenter Utrecht
+# - Expatcenter Amsterdam
 TARGET_CITIES=
 

--- a/internal/pkg/appointments/appointments_test.go
+++ b/internal/pkg/appointments/appointments_test.go
@@ -19,38 +19,63 @@ func TestBiometrics(t *testing.T) {
 		got := appointments.Biometrics()
 		want := []models.URL{
 			{
-				City:       models.Amsterdam,
+				City:       models.INDAmsterdam,
 				Endpoint:   "/AM/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
 			},
 			{
-				City:       models.TheHague,
+				City:       models.INDDenHaag,
 				Endpoint:   "/DH/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
 			},
 			{
-				City:       models.Rotterdam,
-				Endpoint:   "/RO/slots/?productKey=BIO&persons=1",
-				ProductKey: "BIO",
-			},
-			{
-				City:       models.Zwolle,
+				City:       models.INDZwolle,
 				Endpoint:   "/ZW/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
 			},
 			{
-				City:       models.DenBosch,
+				City:       models.INDDenBosch,
 				Endpoint:   "/DB/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
 			},
 			{
-				City:       models.Haarlem,
+				City:       models.INDRotterdam,
+				Endpoint:   "/RO/slots/?productKey=BIO&persons=1",
+				ProductKey: "BIO",
+			},
+			{
+				City:       models.INDHaarlem,
 				Endpoint:   "/6b425ff9f87de136a36b813cccf26e23/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
 			},
 			{
-				City:       models.Utrecht,
-				Endpoint:   "/fa24ccf0acbc76a7793765937eaee440/slots/?productKey=BIO&persons=1",
+				City:       models.ExpatGroningen,
+				Endpoint:   "/0c127eb6d9fe1ced413d2112305e75f6/slots/?productKey=BIO&persons=1",
+				ProductKey: "BIO",
+			},
+			{
+				City:       models.ExpatMaastricht,
+				Endpoint:   "/6c5280823686521552efe85094e607cf/slots/?productKey=BIO&persons=1",
+				ProductKey: "BIO",
+			},
+			{
+				City:       models.ExpatWageningen,
+				Endpoint:   "/b084907207cfeea941cd9698821fd894/slots/?productKey=BIO&persons=1",
+				ProductKey: "BIO",
+			},
+			{
+				City:       models.ExpatEindhoven,
+				Endpoint:   "/0588ef4088c08f53294eb60bab55c81e/slots/?productKey=BIO&persons=1",
+				ProductKey: "BIO",
+			},
+			{
+				City:       models.ExpatDenHaag,
+				Endpoint:   "/5e325f444aeb56bb0270a61b4a0403eb/slots/?productKey=BIO&persons=1",
+				ProductKey: "BIO",
+			},
+			{
+				City:       models.ExpatRotterdam,
+				Endpoint:   "/f0ef3c8f0973875936329d713a68c5f3/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
 			},
 			{
@@ -59,8 +84,13 @@ func TestBiometrics(t *testing.T) {
 				ProductKey: "BIO",
 			},
 			{
-				City:       models.ExpatRotterdam,
-				Endpoint:   "/f0ef3c8f0973875936329d713a68c5f3/slots/?productKey=BIO&persons=1",
+				City:       models.ExpatUtrecht,
+				Endpoint:   "/fa24ccf0acbc76a7793765937eaee440/slots/?productKey=BIO&persons=1",
+				ProductKey: "BIO",
+			},
+			{
+				City:       models.ExpatAmsterdam,
+				Endpoint:   "/284b189314071dcd571df5bb262a31db/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
 			},
 		}
@@ -68,7 +98,7 @@ func TestBiometrics(t *testing.T) {
 	})
 
 	t.Run("select cities", func(t *testing.T) {
-		_ = os.Setenv("TARGET_CITIES", "Amsterdam, The Hague,Expat center Enschede")
+		_ = os.Setenv("TARGET_CITIES", "IND Amsterdam, IND Den Haag,Expatcenter Enschede")
 		defer func() {
 			_ = os.Unsetenv("TARGET_CITIES")
 		}()
@@ -77,12 +107,12 @@ func TestBiometrics(t *testing.T) {
 		got := appointments.Biometrics()
 		want := []models.URL{
 			{
-				City:       models.Amsterdam,
+				City:       models.INDAmsterdam,
 				Endpoint:   "/AM/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
 			},
 			{
-				City:       models.TheHague,
+				City:       models.INDDenHaag,
 				Endpoint:   "/DH/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
 			},
@@ -103,27 +133,22 @@ func TestResidenceSticker(t *testing.T) {
 		got := appointments.ResidenceSticker()
 		want := []models.URL{
 			{
-				City:       models.Amsterdam,
+				City:       models.INDAmsterdam,
 				Endpoint:   "/AM/slots/?productKey=VAA&persons=1",
 				ProductKey: "VAA",
 			},
 			{
-				City:       models.TheHague,
+				City:       models.INDDenHaag,
 				Endpoint:   "/DH/slots/?productKey=VAA&persons=1",
 				ProductKey: "VAA",
 			},
 			{
-				City:       models.Rotterdam,
-				Endpoint:   "/RO/slots/?productKey=VAA&persons=1",
-				ProductKey: "VAA",
-			},
-			{
-				City:       models.Zwolle,
+				City:       models.INDZwolle,
 				Endpoint:   "/ZW/slots/?productKey=VAA&persons=1",
 				ProductKey: "VAA",
 			},
 			{
-				City:       models.DenBosch,
+				City:       models.INDDenBosch,
 				Endpoint:   "/DB/slots/?productKey=VAA&persons=1",
 				ProductKey: "VAA",
 			},
@@ -133,7 +158,7 @@ func TestResidenceSticker(t *testing.T) {
 	})
 
 	t.Run("selected cities", func(t *testing.T) {
-		_ = os.Setenv("TARGET_CITIES", "Amsterdam, Rotterdam")
+		_ = os.Setenv("TARGET_CITIES", "IND Amsterdam, IND Zwolle")
 		defer func() {
 			_ = os.Unsetenv("TARGET_CITIES")
 		}()
@@ -142,13 +167,13 @@ func TestResidenceSticker(t *testing.T) {
 		got := appointments.ResidenceSticker()
 		want := []models.URL{
 			{
-				City:       models.Amsterdam,
+				City:       models.INDAmsterdam,
 				Endpoint:   "/AM/slots/?productKey=VAA&persons=1",
 				ProductKey: "VAA",
 			},
 			{
-				City:       models.Rotterdam,
-				Endpoint:   "/RO/slots/?productKey=VAA&persons=1",
+				City:       models.INDZwolle,
+				Endpoint:   "/ZW/slots/?productKey=VAA&persons=1",
 				ProductKey: "VAA",
 			},
 		}
@@ -164,27 +189,22 @@ func TestResidence(t *testing.T) {
 		got := appointments.ResidenceCard()
 		want := []models.URL{
 			{
-				City:       models.Amsterdam,
+				City:       models.INDAmsterdam,
 				Endpoint:   "/AM/slots/?productKey=DOC&persons=1",
 				ProductKey: "DOC",
 			},
 			{
-				City:       models.TheHague,
+				City:       models.INDDenHaag,
 				Endpoint:   "/DH/slots/?productKey=DOC&persons=1",
 				ProductKey: "DOC",
 			},
 			{
-				City:       models.Rotterdam,
-				Endpoint:   "/RO/slots/?productKey=DOC&persons=1",
-				ProductKey: "DOC",
-			},
-			{
-				City:       models.Zwolle,
+				City:       models.INDZwolle,
 				Endpoint:   "/ZW/slots/?productKey=DOC&persons=1",
 				ProductKey: "DOC",
 			},
 			{
-				City:       models.DenBosch,
+				City:       models.INDDenBosch,
 				Endpoint:   "/DB/slots/?productKey=DOC&persons=1",
 				ProductKey: "DOC",
 			},
@@ -194,7 +214,7 @@ func TestResidence(t *testing.T) {
 	})
 
 	t.Run("selected cities", func(t *testing.T) {
-		_ = os.Setenv("TARGET_CITIES", "Amsterdam, Zwolle")
+		_ = os.Setenv("TARGET_CITIES", "IND Amsterdam, IND Zwolle")
 		defer func() {
 			_ = os.Unsetenv("TARGET_CITIES")
 		}()
@@ -203,12 +223,12 @@ func TestResidence(t *testing.T) {
 		got := appointments.ResidenceCard()
 		want := []models.URL{
 			{
-				City:       models.Amsterdam,
+				City:       models.INDAmsterdam,
 				Endpoint:   "/AM/slots/?productKey=DOC&persons=1",
 				ProductKey: "VAA",
 			},
 			{
-				City:       models.Zwolle,
+				City:       models.INDZwolle,
 				Endpoint:   "/ZW/slots/?productKey=DOC&persons=1",
 				ProductKey: "DOC",
 			},
@@ -221,7 +241,7 @@ func TestResidence(t *testing.T) {
 func TestProcess(t *testing.T) {
 	const productKey = "VAA"
 	want := models.Availabilities{
-		City:   models.Amsterdam,
+		City:   models.INDAmsterdam,
 		Status: http.StatusText(http.StatusOK),
 		Data: []models.Availability{
 			{
@@ -240,7 +260,7 @@ func TestProcess(t *testing.T) {
 	defer svr.Close()
 	c := client.NewClient(svr.URL)
 
-	xu := []models.URL{models.NewURL(models.Amsterdam, productKey)}
+	xu := []models.URL{models.NewURL(models.INDAmsterdam, productKey)}
 	got := appointments.Process(c, xu)
 
 	if !got[0].Equal(want) {

--- a/internal/pkg/models/city.go
+++ b/internal/pkg/models/city.go
@@ -6,24 +6,36 @@ type City string
 // Abbrev abbreviates the city to its initials.
 func (c City) Abbrev() string {
 	switch c.String() {
-	case Amsterdam.String():
+	case INDAmsterdam.String():
 		return "AM"
-	case TheHague.String():
+	case INDDenHaag.String():
 		return "DH"
-	case Rotterdam.String():
-		return "RO"
-	case Zwolle.String():
+	case INDZwolle.String():
 		return "ZW"
-	case DenBosch.String():
+	case INDDenBosch.String():
 		return "DB"
-	case Haarlem.String():
+	case INDRotterdam.String():
+		return "RO"
+	case INDHaarlem.String():
 		return "6b425ff9f87de136a36b813cccf26e23"
-	case Utrecht.String():
-		return "fa24ccf0acbc76a7793765937eaee440"
-	case ExpatEnschede.String():
-		return "3535aca0fb9a2e8e8015f768fb3fa69d"
+	case ExpatGroningen.String():
+		return "0c127eb6d9fe1ced413d2112305e75f6"
+	case ExpatMaastricht.String():
+		return "6c5280823686521552efe85094e607cf"
+	case ExpatWageningen.String():
+		return "b084907207cfeea941cd9698821fd894"
+	case ExpatEindhoven.String():
+		return "0588ef4088c08f53294eb60bab55c81e"
+	case ExpatDenHaag.String():
+		return "5e325f444aeb56bb0270a61b4a0403eb"
 	case ExpatRotterdam.String():
 		return "f0ef3c8f0973875936329d713a68c5f3"
+	case ExpatEnschede.String():
+		return "3535aca0fb9a2e8e8015f768fb3fa69d"
+	case ExpatUtrecht.String():
+		return "fa24ccf0acbc76a7793765937eaee440"
+	case ExpatAmsterdam.String():
+		return "284b189314071dcd571df5bb262a31db"
 	default:
 		return c.String()
 	}
@@ -36,46 +48,56 @@ func (c City) String() string {
 
 // Constants for various cities in The Netherlands.
 const (
-	Amsterdam      = City("Amsterdam")
-	TheHague       = City("The Hague")
-	Rotterdam      = City("Rotterdam")
-	Zwolle         = City("Zwolle")
-	DenBosch       = City("Den Bosch")
-	Haarlem        = City("IND Haarlem")
-	Utrecht        = City("Expat center Utrecht")
-	ExpatRotterdam = City("Expat center Rotterdam")
-	ExpatEnschede  = City("Expat center Enschede")
+	INDAmsterdam    = City("IND Amsterdam")
+	INDDenHaag      = City("IND Den Haag")
+	INDZwolle       = City("IND Zwolle")
+	INDDenBosch     = City("IND Den Bosch")
+	INDRotterdam    = City("IND Rotterdam")
+	INDHaarlem      = City("IND Haarlem")
+	ExpatGroningen  = City("Expatcenter Groningen")
+	ExpatMaastricht = City("Expatcenter Maastricht")
+	ExpatWageningen = City("Expatcenter Wageningen")
+	ExpatEindhoven  = City("Expatcenter Eidhoven")
+	ExpatDenHaag    = City("Expatcenter Den Haag")
+	ExpatRotterdam  = City("Expatcenter Rotterdam")
+	ExpatEnschede   = City("Expatcenter Enschede")
+	ExpatUtrecht    = City("Expatcenter Utrecht")
+	ExpatAmsterdam  = City("Expatcenter Amsterdam")
 )
 
 // BiometricCities is the list of cities that offer appointments for biometrics.
 var BiometricCities = map[string]City{
-	"AM":                               Amsterdam,
-	"DH":                               TheHague,
-	"RO":                               Rotterdam,
-	"ZW":                               Zwolle,
-	"DB":                               DenBosch,
-	"6b425ff9f87de136a36b813cccf26e23": Haarlem,
-	"fa24ccf0acbc76a7793765937eaee440": Utrecht,
-	"3535aca0fb9a2e8e8015f768fb3fa69d": ExpatEnschede,
+	"AM":                               INDAmsterdam,
+	"DH":                               INDDenHaag,
+	"ZW":                               INDZwolle,
+	"DB":                               INDDenBosch,
+	"RO":                               INDRotterdam,
+	"6b425ff9f87de136a36b813cccf26e23": INDHaarlem,
+	"0c127eb6d9fe1ced413d2112305e75f6": ExpatGroningen,
+	"6c5280823686521552efe85094e607cf": ExpatMaastricht,
+	"b084907207cfeea941cd9698821fd894": ExpatWageningen,
+	"0588ef4088c08f53294eb60bab55c81e": ExpatEindhoven,
+	"5e325f444aeb56bb0270a61b4a0403eb": ExpatDenHaag,
 	"f0ef3c8f0973875936329d713a68c5f3": ExpatRotterdam,
+	"3535aca0fb9a2e8e8015f768fb3fa69d": ExpatEnschede,
+	"fa24ccf0acbc76a7793765937eaee440": ExpatUtrecht,
+	"284b189314071dcd571df5bb262a31db": ExpatAmsterdam,
 }
 
 // ResidenceStickerCities is the list of cities that offer
 // appointments for the residence sticker.
 var ResidenceStickerCities = map[string]City{
-	"AM": Amsterdam,
-	"DH": TheHague,
-	"RO": Rotterdam,
-	"ZW": Zwolle,
-	"DB": DenBosch,
+	"AM": INDAmsterdam,
+	"DH": INDDenHaag,
+	"ZW": INDZwolle,
+	"DB": INDDenBosch,
 }
 
 // ResidenceCardCities is the list of cities that offer
 // appointments to collect the residence card.
 var ResidenceCardCities = map[string]City{
-	"AM": Amsterdam,
-	"DH": TheHague,
-	"RO": Rotterdam,
-	"ZW": Zwolle,
-	"DB": DenBosch,
+	"AM": INDAmsterdam,
+	"DH": INDDenHaag,
+	"ZW": INDZwolle,
+	"DB": INDDenBosch,
 }


### PR DESCRIPTION
Hi! This is a breaking change, because it switches to a naming convention that is consistent with the IND website, breaking existing configurations. I think the better user experience is worth the hassle, but it's your call if you want to merge it.

The core of the change, however, is a resync with the available desks on the IND website, adding support for the many Expat Centers that are now listed for the Biometrics appointments. IND Rotterdam is also not selectable anymore for Residence Card and Residence Stickers, so I removed it.