### PR TITLE
Allow to configure the number of persons to book for

### DIFF
--- a/.env
+++ b/.env
@@ -8,7 +8,7 @@ IND_CURRENT_APPOINTMENT_BIOMETRICS=
 IND_CURRENT_APPOINTMENT_RESIDENCE_STICKER=
 IND_CURRENT_APPOINTMENT_RESIDENCE_CARD=
 
-# Comma-seperated list of cities/desks you want to target.
+# Comma-separated list of cities/desks you want to target.
 #
 # All cities/desks will be selected if the value is empty.
 # Otherwise, enumerate them from the options below:
@@ -29,3 +29,6 @@ IND_CURRENT_APPOINTMENT_RESIDENCE_CARD=
 # - Expatcenter Amsterdam
 TARGET_CITIES=
 
+# Total number of persons for which to request an appointment, between 1 and 6.
+# If empty or invalid, it defaults to 1.
+TOTAL_PERSONS=1

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ release
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Vim swap files
+[._]*.sw[a-p]

--- a/internal/pkg/appointments/appointments.go
+++ b/internal/pkg/appointments/appointments.go
@@ -12,20 +12,20 @@ import (
 
 // Biometrics prepares all URLs for the biometrics appointment.
 func Biometrics() []models.URL {
-	return makeURLs(constants.ProductKeyBiometrics, models.BiometricCities)
+	return makeURLs(constants.ProductKeyBiometrics, models.BiometricCities, config.Config.Persons)
 }
 
 // ResidenceSticker prepares all URLs for the residence sticker appointment.
 func ResidenceSticker() []models.URL {
-	return makeURLs(constants.ProductKeyResidenceSticker, models.ResidenceStickerCities)
+	return makeURLs(constants.ProductKeyResidenceSticker, models.ResidenceStickerCities, config.Config.Persons)
 }
 
 // ResidenceCard prepares all URLs for the residence card collection appointment.
 func ResidenceCard() []models.URL {
-	return makeURLs(constants.ProductKeyResidenceCard, models.ResidenceCardCities)
+	return makeURLs(constants.ProductKeyResidenceCard, models.ResidenceCardCities, config.Config.Persons)
 }
 
-func makeURLs(productKey string, cities map[string]models.City) []models.URL {
+func makeURLs(productKey string, cities map[string]models.City, persons int) []models.URL {
 	if len(config.Config.Cities) > 0 {
 		cities = config.Config.Cities
 	}
@@ -33,7 +33,7 @@ func makeURLs(productKey string, cities map[string]models.City) []models.URL {
 	xr := make([]models.URL, len(cities))
 	i := 0
 	for _, city := range cities {
-		xr[i] = models.NewURL(city, productKey)
+		xr[i] = models.NewURL(city, productKey, persons)
 		i++
 	}
 	return xr

--- a/internal/pkg/appointments/appointments_test.go
+++ b/internal/pkg/appointments/appointments_test.go
@@ -22,76 +22,91 @@ func TestBiometrics(t *testing.T) {
 				City:       models.INDAmsterdam,
 				Endpoint:   "/AM/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
+				Persons:    1,
 			},
 			{
 				City:       models.INDDenHaag,
 				Endpoint:   "/DH/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
+				Persons:    1,
 			},
 			{
 				City:       models.INDZwolle,
 				Endpoint:   "/ZW/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
+				Persons:    1,
 			},
 			{
 				City:       models.INDDenBosch,
 				Endpoint:   "/DB/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
+				Persons:    1,
 			},
 			{
 				City:       models.INDRotterdam,
 				Endpoint:   "/RO/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
+				Persons:    1,
 			},
 			{
 				City:       models.INDHaarlem,
 				Endpoint:   "/6b425ff9f87de136a36b813cccf26e23/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
+				Persons:    1,
 			},
 			{
 				City:       models.ExpatGroningen,
 				Endpoint:   "/0c127eb6d9fe1ced413d2112305e75f6/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
+				Persons:    1,
 			},
 			{
 				City:       models.ExpatMaastricht,
 				Endpoint:   "/6c5280823686521552efe85094e607cf/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
+				Persons:    1,
 			},
 			{
 				City:       models.ExpatWageningen,
 				Endpoint:   "/b084907207cfeea941cd9698821fd894/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
+				Persons:    1,
 			},
 			{
 				City:       models.ExpatEindhoven,
 				Endpoint:   "/0588ef4088c08f53294eb60bab55c81e/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
+				Persons:    1,
 			},
 			{
 				City:       models.ExpatDenHaag,
 				Endpoint:   "/5e325f444aeb56bb0270a61b4a0403eb/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
+				Persons:    1,
 			},
 			{
 				City:       models.ExpatRotterdam,
 				Endpoint:   "/f0ef3c8f0973875936329d713a68c5f3/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
+				Persons:    1,
 			},
 			{
 				City:       models.ExpatEnschede,
 				Endpoint:   "/3535aca0fb9a2e8e8015f768fb3fa69d/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
+				Persons:    1,
 			},
 			{
 				City:       models.ExpatUtrecht,
 				Endpoint:   "/fa24ccf0acbc76a7793765937eaee440/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
+				Persons:    1,
 			},
 			{
 				City:       models.ExpatAmsterdam,
 				Endpoint:   "/284b189314071dcd571df5bb262a31db/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
+				Persons:    1,
 			},
 		}
 		assertURLs(t, got, want)
@@ -110,16 +125,19 @@ func TestBiometrics(t *testing.T) {
 				City:       models.INDAmsterdam,
 				Endpoint:   "/AM/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
+				Persons:    1,
 			},
 			{
 				City:       models.INDDenHaag,
 				Endpoint:   "/DH/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
+				Persons:    1,
 			},
 			{
 				City:       models.ExpatEnschede,
 				Endpoint:   "/3535aca0fb9a2e8e8015f768fb3fa69d/slots/?productKey=BIO&persons=1",
 				ProductKey: "BIO",
+				Persons:    1,
 			},
 		}
 		assertURLs(t, got, want)
@@ -136,21 +154,25 @@ func TestResidenceSticker(t *testing.T) {
 				City:       models.INDAmsterdam,
 				Endpoint:   "/AM/slots/?productKey=VAA&persons=1",
 				ProductKey: "VAA",
+				Persons:    1,
 			},
 			{
 				City:       models.INDDenHaag,
 				Endpoint:   "/DH/slots/?productKey=VAA&persons=1",
 				ProductKey: "VAA",
+				Persons:    1,
 			},
 			{
 				City:       models.INDZwolle,
 				Endpoint:   "/ZW/slots/?productKey=VAA&persons=1",
 				ProductKey: "VAA",
+				Persons:    1,
 			},
 			{
 				City:       models.INDDenBosch,
 				Endpoint:   "/DB/slots/?productKey=VAA&persons=1",
 				ProductKey: "VAA",
+				Persons:    1,
 			},
 		}
 
@@ -170,11 +192,13 @@ func TestResidenceSticker(t *testing.T) {
 				City:       models.INDAmsterdam,
 				Endpoint:   "/AM/slots/?productKey=VAA&persons=1",
 				ProductKey: "VAA",
+				Persons:    1,
 			},
 			{
 				City:       models.INDZwolle,
 				Endpoint:   "/ZW/slots/?productKey=VAA&persons=1",
 				ProductKey: "VAA",
+				Persons:    1,
 			},
 		}
 
@@ -192,21 +216,25 @@ func TestResidence(t *testing.T) {
 				City:       models.INDAmsterdam,
 				Endpoint:   "/AM/slots/?productKey=DOC&persons=1",
 				ProductKey: "DOC",
+				Persons:    1,
 			},
 			{
 				City:       models.INDDenHaag,
 				Endpoint:   "/DH/slots/?productKey=DOC&persons=1",
 				ProductKey: "DOC",
+				Persons:    1,
 			},
 			{
 				City:       models.INDZwolle,
 				Endpoint:   "/ZW/slots/?productKey=DOC&persons=1",
 				ProductKey: "DOC",
+				Persons:    1,
 			},
 			{
 				City:       models.INDDenBosch,
 				Endpoint:   "/DB/slots/?productKey=DOC&persons=1",
 				ProductKey: "DOC",
+				Persons:    1,
 			},
 		}
 
@@ -226,11 +254,77 @@ func TestResidence(t *testing.T) {
 				City:       models.INDAmsterdam,
 				Endpoint:   "/AM/slots/?productKey=DOC&persons=1",
 				ProductKey: "VAA",
+				Persons:    1,
 			},
 			{
 				City:       models.INDZwolle,
 				Endpoint:   "/ZW/slots/?productKey=DOC&persons=1",
 				ProductKey: "DOC",
+				Persons:    1,
+			},
+		}
+
+		assertURLs(t, got, want)
+	})
+}
+
+func TestPersons(t *testing.T) {
+	t.Run("all cities", func(t *testing.T) {
+		config.Init()
+
+		got := appointments.ResidenceSticker()
+		want := []models.URL{
+			{
+				City:       models.INDAmsterdam,
+				Endpoint:   "/AM/slots/?productKey=VAA&persons=1",
+				ProductKey: "VAA",
+				Persons:    1,
+			},
+			{
+				City:       models.INDDenHaag,
+				Endpoint:   "/DH/slots/?productKey=VAA&persons=1",
+				ProductKey: "VAA",
+				Persons:    1,
+			},
+			{
+				City:       models.INDZwolle,
+				Endpoint:   "/ZW/slots/?productKey=VAA&persons=1",
+				ProductKey: "VAA",
+				Persons:    1,
+			},
+			{
+				City:       models.INDDenBosch,
+				Endpoint:   "/DB/slots/?productKey=VAA&persons=1",
+				ProductKey: "VAA",
+				Persons:    1,
+			},
+		}
+
+		assertURLs(t, got, want)
+	})
+
+	t.Run("selected cities", func(t *testing.T) {
+		_ = os.Setenv("TARGET_CITIES", "IND Amsterdam, IND Zwolle")
+		_ = os.Setenv("TOTAL_PERSONS", "4")
+		defer func() {
+			_ = os.Unsetenv("TARGET_CITIES")
+			_ = os.Unsetenv("TOTAL_PERSONS")
+		}()
+		config.Init()
+
+		got := appointments.ResidenceSticker()
+		want := []models.URL{
+			{
+				City:       models.INDAmsterdam,
+				Endpoint:   "/AM/slots/?productKey=VAA&persons=4",
+				ProductKey: "VAA",
+				Persons:    4,
+			},
+			{
+				City:       models.INDZwolle,
+				Endpoint:   "/ZW/slots/?productKey=VAA&persons=4",
+				ProductKey: "VAA",
+				Persons:    4,
 			},
 		}
 
@@ -240,9 +334,11 @@ func TestResidence(t *testing.T) {
 
 func TestProcess(t *testing.T) {
 	const productKey = "VAA"
+	const persons = 6
 	want := models.Availabilities{
-		City:   models.INDAmsterdam,
-		Status: http.StatusText(http.StatusOK),
+		City:    models.INDAmsterdam,
+		Persons: persons,
+		Status:  http.StatusText(http.StatusOK),
 		Data: []models.Availability{
 			{
 				Key:       productKey,
@@ -260,7 +356,7 @@ func TestProcess(t *testing.T) {
 	defer svr.Close()
 	c := client.NewClient(svr.URL)
 
-	xu := []models.URL{models.NewURL(models.INDAmsterdam, productKey)}
+	xu := []models.URL{models.NewURL(models.INDAmsterdam, productKey, persons)}
 	got := appointments.Process(c, xu)
 
 	if !got[0].Equal(want) {

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"github.com/reaper47/ind-appointment-checker/internal/pkg/constants"
 	"github.com/reaper47/ind-appointment-checker/internal/pkg/models"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -16,6 +18,7 @@ type config struct {
 	CurrAppointmentResidenceSticker time.Time
 	CurrAppointmentResidenceCard    time.Time
 	Cities                          map[string]models.City
+	Persons                         int
 }
 
 // Init initializes the Config struct with the environment variables from the .env file.
@@ -53,11 +56,17 @@ func Init() {
 		}
 	}
 
+	persons, err := strconv.Atoi(os.Getenv("TOTAL_PERSONS"))
+	if err != nil || persons <= 0 || persons > constants.MaxPersons {
+		persons = 1
+	}
+
 	Config = config{
 		StartDate:                       startDate,
 		CurrAppointmentBiometrics:       biometrics,
 		CurrAppointmentResidenceSticker: sticker,
 		CurrAppointmentResidenceCard:    card,
 		Cities:                          citiesMap,
+		Persons:                         persons,
 	}
 }

--- a/internal/pkg/constants/keys.go
+++ b/internal/pkg/constants/keys.go
@@ -9,3 +9,7 @@ const (
 
 // BaseURL is the base URL for IND's API.
 const BaseURL = "https://oap.ind.nl/oap/api/desks"
+
+// MaxPersons is the maximum number of persons for which an appointment can be
+// requested.
+const MaxPersons = 6

--- a/internal/pkg/jobs/jobs.go
+++ b/internal/pkg/jobs/jobs.go
@@ -54,11 +54,11 @@ func watchAppointments(c client.Client, urls allURLs) {
 
 func checkAvailabilities(availabilities []models.Availabilities, currAppointmentDate time.Time, productKey string) {
 	for _, avail := range availabilities {
-		checkDates(avail.Data, avail.City, currAppointmentDate, productKey)
+		checkDates(avail.Data, avail.City, avail.Persons, currAppointmentDate, productKey)
 	}
 }
 
-func checkDates(availabilities []models.Availability, city models.City, currDate time.Time, productKey string) {
+func checkDates(availabilities []models.Availability, city models.City, persons int, currDate time.Time, productKey string) {
 	for _, availability := range availabilities {
 		date, err := time.Parse("2006-01-02", availability.Date)
 		if err != nil {
@@ -82,8 +82,8 @@ func checkDates(availabilities []models.Availability, city models.City, currDate
 			}
 
 			text := fmt.Sprintf(
-				"%s:\nAn earlier %s appointment is available on %s at %s.\nBook an appointment now: https://oap.ind.nl/oap/en/#/%s",
-				city, name, date.Format("02 Jan 2006"), startTime.Format("15:04"), productKey,
+				"%s:\nAn earlier %s appointment for %d person(s) is available on %s at %s.\nBook an appointment now: https://oap.ind.nl/oap/en/#/%s",
+				city, name, persons, date.Format("02 Jan 2006"), startTime.Format("15:04"), productKey,
 			)
 			text = strings.ReplaceAll(text, "/#", "/%23")
 			bot.SendMessage(strings.ReplaceAll(text, "\n", "%0A"))

--- a/internal/pkg/models/availability.go
+++ b/internal/pkg/models/availability.go
@@ -5,17 +5,18 @@ import "golang.org/x/exp/slices"
 // Availabilities is a representation of the response
 // received from IND when after selecting a city.
 //
-// The City field has been added for convenience to
-// associate the availabilities to the city.
+// The City and Persons fields have been added for convenience to
+// associate the availabilities to the city and the number of people.
 type Availabilities struct {
-	City   City
-	Status string         `json:"status"`
-	Data   []Availability `json:"data"`
+	City    City
+	Persons int
+	Status  string         `json:"status"`
+	Data    []Availability `json:"data"`
 }
 
 // Equal verifies the Availabilities structs are identical.
 func (a Availabilities) Equal(other Availabilities) bool {
-	return a.City == other.City && a.Status == other.Status && slices.Equal(a.Data, other.Data)
+	return a.City == other.City && a.Persons == other.Persons && a.Status == other.Status && slices.Equal(a.Data, other.Data)
 }
 
 // Availability is a representation of the response.data field of

--- a/internal/pkg/models/url.go
+++ b/internal/pkg/models/url.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/reaper47/ind-appointment-checker/internal/pkg/client"
+	"github.com/reaper47/ind-appointment-checker/internal/pkg/constants"
 	"io/ioutil"
 	"net/http"
 )
@@ -14,11 +15,12 @@ type URL struct {
 	City       City
 	Endpoint   string
 	ProductKey string
+	Persons    int
 }
 
 // Equal verifies the URLs are identical.
 func (u URL) Equal(other URL) bool {
-	return u.City == other.City && u.Endpoint == other.Endpoint
+	return u.City == other.City && u.Endpoint == other.Endpoint && u.Persons == other.Persons
 }
 
 // Process fetches appointments for the URL struct.
@@ -44,14 +46,20 @@ func (u URL) Process(c client.Client) (Availabilities, error) {
 		return Availabilities{}, fmt.Errorf("unable to unmarshal json for %s: %s", u.Endpoint, err)
 	}
 	availability.City = u.City
+	availability.Persons = u.Persons
 	return availability, nil
 }
 
 // NewURL creates a Req model from the input City and product key.
-func NewURL(city City, productKey string) URL {
+func NewURL(city City, productKey string, persons int) URL {
+	if persons <= 0 || persons > constants.MaxPersons {
+		persons = 1
+	}
+
 	return URL{
 		City:       city,
-		Endpoint:   "/" + city.Abbrev() + "/slots/?productKey=" + productKey + "&persons=1",
+		Endpoint:   fmt.Sprintf("/%s/slots/?productKey=%s&persons=%d", city.Abbrev(), productKey, persons),
 		ProductKey: productKey,
+		Persons:    persons,
 	}
 }


### PR DESCRIPTION
_Premise: I suck at Go, so please check my changes carefully. :)_

This change introduces a new configuration variable, `TOTAL_PERSONS`, which sets the number of people who need to book an appointment together. Right now the IND allows a maximum of 6 people, with each person's appointment duration set to 10 minutes. Multiple people booking together need consecutive slots to be available.

Configuring the number of persons makes the bot much less noisy for groups of people booking together because most of the slots that free up are long enough for a single person.